### PR TITLE
Use absolute path in forked seastar lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dpdk"]
 	path = dpdk
-	url = ../dpdk
+	url = https://github.com/scylladb/dpdk.git


### PR DESCRIPTION
Relative path gets broken when you fork the repo